### PR TITLE
Fix VenusE power fallback, scaling, and UDP command collisions

### DIFF
--- a/custom_components/marstek_local_api/api.py
+++ b/custom_components/marstek_local_api/api.py
@@ -41,6 +41,7 @@ _shared_transports = {}
 _shared_protocols = {}
 _transport_refcounts = {}
 _clients_by_port = {}  # Map port -> list of clients
+_shared_command_locks = {}  # Map port -> asyncio.Lock for serializing command/response cycles
 
 
 class MarstekUDPClient:
@@ -160,6 +161,8 @@ class MarstekUDPClient:
                     del _transport_refcounts[self.port]
                 if self.port in _clients_by_port:
                     del _clients_by_port[self.port]
+                if self.port in _shared_command_locks:
+                    del _shared_command_locks[self.port]
                 _LOGGER.debug("Closed shared UDP socket on port %s", self.port)
             else:
                 _LOGGER.debug(
@@ -219,6 +222,23 @@ class MarstekUDPClient:
         max_attempts: int | None = None,
     ) -> dict | None:
         """Send a command and wait for response."""
+        if not self._connected:
+            await self.connect()
+
+        if self.port not in _shared_command_locks:
+            _shared_command_locks[self.port] = asyncio.Lock()
+
+        async with _shared_command_locks[self.port]:
+            return await self._send_command_locked(method, params, timeout, max_attempts)
+
+    async def _send_command_locked(
+        self,
+        method: str,
+        params: dict | None = None,
+        timeout: int | None = None,
+        max_attempts: int | None = None,
+    ) -> dict | None:
+        """Send a command while holding the shared port lock."""
         if not self._connected:
             await self.connect()
 

--- a/custom_components/marstek_local_api/compatibility.py
+++ b/custom_components/marstek_local_api/compatibility.py
@@ -101,7 +101,8 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 1.0,      # FW 0-153: raw value in °C
             (HW_VERSION_2, 154): 0.1,    # FW 154+: raw value in deci-°C (÷0.1 = ×10)
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in °C
-            (HW_VERSION_3, 139): 10.0,   # FW 0+: raw value in deca-°C (÷10)
+            (HW_VERSION_3, 139): 10.0,   # FW 139-142: raw value in deca-°C (÷10)
+            (HW_VERSION_3, 143): 1.0,    # FW 143+: raw value in °C
         },
 
         # Battery capacity (Wh)
@@ -109,7 +110,8 @@ class CompatibilityMatrix:
             (HW_VERSION_2, 0): 100.0,    # FW 0-153: raw value in centi-Wh (÷100)
             (HW_VERSION_2, 154): 1.0,    # FW 154+: raw value in Wh
             (HW_VERSION_3, 0): 1.0,      # FW 0+: raw value in Wh
-            (HW_VERSION_3, 139): 0.1,      # FW 0+: raw value in deci-Wh (÷0.1)
+            (HW_VERSION_3, 139): 0.1,    # FW 139-142: raw value in deci-Wh (÷0.1)
+            (HW_VERSION_3, 143): 1.0,    # FW 143+: raw value in Wh
         },
 
         # Battery power (W)

--- a/custom_components/marstek_local_api/coordinator.py
+++ b/custom_components/marstek_local_api/coordinator.py
@@ -478,6 +478,16 @@ class MarstekDataUpdateCoordinator(DataUpdateCoordinator):
                     es_status["bat_power"] = self.compatibility.scale_value(
                         es_status["bat_power"], "bat_power"
                     )
+                elif es_status.get("ongrid_power") is not None:
+                    try:
+                        # Some VenusE firmware versions omit bat_power but report
+                        # battery flow as ongrid_power with the opposite sign.
+                        es_status["bat_power"] = -float(es_status["ongrid_power"])
+                    except (TypeError, ValueError):
+                        _LOGGER.debug(
+                            "Could not derive bat_power from ongrid_power=%r",
+                            es_status.get("ongrid_power"),
+                        )
                 if "total_grid_input_energy" in es_status:
                     es_status["total_grid_input_energy"] = self.compatibility.scale_value(
                         es_status["total_grid_input_energy"], "total_grid_input_energy"


### PR DESCRIPTION
## Summary

This PR combines three small fixes that address several current VenusE reports:

- serialize UDP command/response cycles per shared local port to avoid concurrent coordinator collisions
- derive missing `es.bat_power` from `es.ongrid_power` when firmware omits `bat_power`
- restore direct HW3/FW143+ `bat_temp` and `bat_capacity` scaling while keeping the existing FW139-142 scaling behavior

## Issue mapping

- Fixes #119: VenusE FW156 omits `bat_power`, so power in/out, state, and aggregate power sensors stay at 0/idle.
- Fixes #110: multiple coordinators can share a UDP socket but currently send commands concurrently.
- Fixes #52: VenusE 3.0 FW144 reports temperature/capacity in final units and should not use the FW139 scaling.
- Addresses #76 and #91: state can remain idle when `bat_power` is absent even though `ongrid_power` shows charge/discharge flow.
- Related to #43, which targets the same FW143+ scaling problem.

## Notes

For the `ongrid_power` fallback, this uses the sign convention documented in #119:

- `ongrid_power < 0` means charging
- `bat_power > 0` is the existing integration convention for charging

So the derived value is `bat_power = -ongrid_power`.

## Validation

- `python3 -m py_compile custom_components/marstek_local_api/*.py`
- `git diff --check`
- `python3 test/test_tool.py --help`
- local smoke check of HW3 scaling thresholds for FW139, FW142, FW143, FW144, and FW148
